### PR TITLE
'show fret locations as ASCII diagram(s)'

### DIFF
--- a/src/guitar.rs
+++ b/src/guitar.rs
@@ -118,3 +118,90 @@ impl GuitarString {
         }
     }
 }
+
+pub enum Size {
+    Small,
+    Medium,
+    Large,
+}
+
+pub struct FretDiagram {
+    locations: Vec<FretboardLocation>,
+    size: Size,
+}
+
+impl FretDiagram {
+    pub fn new(locations: Vec<FretboardLocation>, size: Size) -> FretDiagram {
+	FretDiagram { locations, size }
+    }
+}
+
+impl fmt::Display for FretDiagram {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+	let highest_fret = self.locations
+	    .iter()
+	    .fold(5, |acc, fbl| std::cmp::max(fbl.fret_number, acc));
+	
+        match self.size {
+            Size::Small => {
+                writeln!(f, "______  ")?;
+
+                for fret in 1..=highest_fret {
+		    'sstrings: for string in (1..=6).rev() {
+			for loc in self.locations.iter() {
+			    if loc.fret_number == fret && loc.string_number == string {
+				write!(f, "*")?;
+				continue 'sstrings;
+			    }
+			}
+			write!(f, "|")?;
+		    }
+                    write!(f, " {}\n", fret)?;
+		}
+            },
+            Size::Medium => {
+                writeln!(f, "______\n------")?;
+		for fret in 1..=highest_fret {
+		    'mstrings: for string in (1..=6).rev() {
+			for loc in self.locations.iter() {
+			    if loc.fret_number == fret && loc.string_number == string {
+				write!(f, "*")?;
+				continue 'mstrings;
+			    }
+			}
+			write!(f, "|")?;
+                    }
+		    write!(f, "  {}\n------\n", fret)?;
+                }
+            },
+            Size::Large => {
+                writeln!(f, "_|_|_|_|_|_|_\n-|-|-|-|-|-|-")?;
+
+                for fret in 1..=highest_fret {
+                    let mut symbols = std::string::String::new();
+
+		    'lstrings: for string in (1..=6).rev() {
+			for loc in self.locations.iter() {
+			    if loc.fret_number == fret && loc.string_number == string {
+				symbols.push('*');
+				continue 'lstrings;
+			    }
+			}
+			symbols.push('|');
+                    }
+                    let mut symbols = symbols.chars();
+                    writeln!(f, " | | | | | | \n {} {} {} {} {} {}  {}\n |-|-|-|-|-| ",
+                             symbols.next().unwrap(),
+                             symbols.next().unwrap(),
+                             symbols.next().unwrap(),
+                             symbols.next().unwrap(),
+                             symbols.next().unwrap(),
+                             symbols.next().unwrap(),
+                             fret)?;
+                    
+                }
+            },
+        }
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use gitar::{standard_tuning, Guitar, Note};
+use gitar::{standard_tuning, Guitar, Note, FretDiagram, Size};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -31,9 +31,8 @@ fn main() -> anyhow::Result<()> {
 
             let locations = guitar.locations(note);
             if locations.len() > 0 {
-                for fretboard_location in locations {
-                    println!("{}", fretboard_location);
-                }
+                println!("{}", FretDiagram::new(locations, Size::Small));
+                
             } else {
                 println!("No occurences.");
             }


### PR DESCRIPTION
Hi, this is my first time using git/Github (and Rust) so I wanted to have a go at forking/pull request etc so feel free to ignore!  

I think fretboard diagrams would be a nice way to display the same information to beginners, especially if your program could interpret common chord notation, i.e: Cmaj -> x32010 == FretboardLocations -> diagram.