### PR TITLE
Remove trivial pass by reference

### DIFF
--- a/src/note.rs
+++ b/src/note.rs
@@ -17,7 +17,7 @@ impl Note {
         Note { value }
     }
 
-    pub(crate) fn disregard_octave(&self) -> Self {
+    pub(crate) fn disregard_octave(self) -> Self {
         Self {
             value: self.value % 12,
         }


### PR DESCRIPTION
Fixes the clippy lint clippy::trivially_copy_pass_by_ref